### PR TITLE
Fix typo in operator check in raxCompare

### DIFF
--- a/rax-test.c
+++ b/rax-test.c
@@ -666,6 +666,49 @@ int regtest4(void) {
     return 0;
 }
 
+/* Regression test #5: Valid comparison operators in the
+ * implementation of raxCompare are == => =< ?> ?< where
+ * ? can be any character. The documented operators are
+ * == <= >= < >.
+ */
+int regtest5(void) {
+    rax *t = raxNew();
+    raxInsert(rax,(unsigned char*)"a",1,(void*)(long)1,NULL);
+    raxInsert(rax,(unsigned char*)"b",1,(void*)(long)2,NULL);
+    raxInsert(rax,(unsigned char*)"c",1,(void*)(long)3,NULL);
+
+    raxIterator iter;
+    raxStart(&iter,t);
+    raxSeek(&iter,">=",(unsigned char*)"a",1);
+
+    while(raxNext(&iter)) {
+        if(raxCompare(&iter,">=",(unsigned char*)"a",1)) break;
+	return 1;
+    }
+
+    raxSeek(&iter,"<=",(unsigned char*)"c",1);
+    while(raxNext(&iter)) {
+        if(raxCompare(&iter,"<=",(unsigned char*)"c",1)) break;
+	return 1;
+    }
+
+    raxSeek(&iter,">",(unsigned char*)"a",1);
+    while(raxNext(&iter)) {
+        if(raxCompare(&iter,">",(unsigned char*)"a",1)) break;
+	return 1;
+    }
+
+    raxSeek(&iter,"<",(unsigned char*)"c",1);
+    while(raxNext(&iter)) {
+        if(raxCompare(&iter,"<",(unsigned char*)"c",1)) break;
+	return 1;
+    }
+
+    raxStop(&iter);
+    raxFree(t);
+    return 0;
+}
+
 void benchmark(void) {
     for (int mode = 0; mode < 2; mode++) {
         printf("Benchmark with %s keys:\n",

--- a/rax.c
+++ b/rax.c
@@ -1618,8 +1618,8 @@ int raxCompare(raxIterator *iter, const char *op, unsigned char *key, size_t key
     int eq = 0, lt = 0, gt = 0;
 
     if (op[0] == '=' || op[1] == '=') eq = 1;
-    if (op[1] == '>') gt = 1;
-    else if (op[1] == '<') lt = 1;
+    if (op[0] == '>') gt = 1;
+    else if (op[0] == '<') lt = 1;
     else if (op[1] != '=') return 0; /* Syntax error. */
 
     size_t minlen = key_len < iter->key_len ? key_len : iter->key_len;


### PR DESCRIPTION
The method raxCompare is using the following code to check for the valid
operators:

```
if (op[0] == '=' || op[1] == '=') eq = 1;
if (op[1] == '>') gt = 1;
else if (op[1] == '<') lt = 1;
else if (op[1] != '=') return 0; /* Syntax error. */
```

This code does not behave as expected for the operators ">=", ">"
(where we want to set gt to one) and "<=", "<" (where we want to
set lt to one) due to a typo in the if conditions. The fixed condition
should be the following to obtain the expected behavior

```
if (op[0] == '=' || op[1] == '=') eq = 1;
if (op[0] == '>') gt = 1;
else if (op[0] == '<') lt = 1;
else if (op[1] != '=') return 0; /* Syntax error. */
```