### PR TITLE
Building in debug and coverage when issuing the proper env variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,17 @@
-DEBUG?= -g -ggdb
 CFLAGS?= -O2 -Wall -W -std=c99
 LDFLAGS= -lm
 
-# Uncomment the following two lines for coverage testing
-#
-# CFLAGS+=-fprofile-arcs -ftest-coverage
-# LDFLAGS+=-lgcov
+# if DEBUG env var is set, we compile with "debug" cflags
+ifeq ($(DEBUG),1)
+	CFLAGS += -g -ggdb -fno-omit-frame-pointer
+	LDFLAGS += -g -ggdb
+endif
+
+# if COV env var is set, we compile with "coverage" cflags
+ifeq ($(COV),1)
+	CFLAGS+=-fprofile-arcs -ftest-coverage
+	LDFLAGS+=-lgcov
+endif
 
 all: rax-test rax-oom-test
 
@@ -14,13 +20,13 @@ rax-test.o: rax.h
 rax-oom-test.o: rax.h
 
 rax-test: rax-test.o rax.o rc4rand.o crc16.o
-	$(CC) -o $@ $^ $(LDFLAGS) $(DEBUG)
+	$(CC) -o $@ $^ $(LDFLAGS)
 
 rax-oom-test: rax-oom-test.o rax.o
-	$(CC) -o $@ $^ $(LDFLAGS) $(DEBUG)
+	$(CC) -o $@ $^ $(LDFLAGS)
 
 .c.o:
-	$(CC) -c $(CFLAGS) $(DEBUG) $<
+	$(CC) -c $(CFLAGS) $<
 
 clean:
 	rm -f rax-test rax-oom-test *.gcda *.gcov *.gcno *.o


### PR DESCRIPTION
Hi there @antirez , this PR enables building rax in debug and coverage modes by passing DEBUG=1 COV=1 environment variables. 

The reason I opened this PR was that the DEBUG variable within the makefile is to generic and can lead to potential build issues on repos that use rax as a dependency. The following build command on a project ( named myproject ) that relies on rax would not generate a successfull rax build if the parent project uses DEBUG=1 as a normal way to build debug binaries.

`
project1: make DEBUG=1 myproject
`
this would also trigger the build o rax that would fail due to DEBUG flags being now overriden by 1. 
Given that this is a common pratice (use DEBUG=1 env variable ) would you swith to this? wdyt? 


