### PR TITLE
Add CMake build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,11 @@ rax-test
 rax-oom-test
 *.o
 *.dSYM
+*.a
+*.so
+*.dll
+*.exe
+
+CMakeFiles*/
+cmake_install.cmake
+CMakeCache.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.1)
+
+project(rax C)
+
+if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
+    set(RAX_IS_STANDALONE TRUE)
+endif()
+
+option(RAX_BUILD_TESTS "Build rax tests" ${RAX_IS_STANDALONE})
+
+if(RAX_BUILD_TESTS)
+    add_executable(rax-test
+        rax-test.c rax.c rc4rand.c crc16.c
+    )
+    add_executable(rax-oom-test
+        rax-oom-test.c rax.c rc4rand.c crc16.c
+    )
+endif()
+
+add_library(${PROJECT_NAME}
+    rax.c
+)
+
+target_include_directories(${PROJECT_NAME}
+    PUBLIC
+        .
+)

--- a/README.md
+++ b/README.md
@@ -486,3 +486,22 @@ in order to narrow down the state causing a give bug:
 
 This method was used with success during rafactorings in order to debug the
 introduced bugs.
+
+# Build with CMake
+
+As standalone project with tests
+```
+cmake . -Bbuild
+cmake --build build
+```
+
+As part of other project
+>Simply add the following lines into your top level CMakeLists.txt
+```
+add_subdirectory(<relative path to rax directory>)
+...
+target_link_libraries(<your target name>
+    PRIVATE
+        rax
+)
+```


### PR DESCRIPTION
With this changes it is possible to easily integrate rax into any CMake project as well as build it as standalone project.