### PR TITLE
[readme] fix a wrong interface doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ of 'seek', which is not 'seeked', in case you wonder) in order to start
 the iteration from the specified position. For this goal, the function
 `raxSeek` is used:
 
-    int raxSeek(raxIterator *it, unsigned char *ele, size_t len, const char *op);
+    int raxSeek(raxIterator *it, const char *op, unsigned char *ele, size_t len);
 
 For instance one may want to seek the first element greater or equal to the
 key `"foo"`:


### PR DESCRIPTION
op should be the second parameter but not the last one.

Signed-off-by: Junwang Zhao <zhjwpku@gmail.com>